### PR TITLE
Fix linter warning --needs_exposed_ports $peer_port

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,14 +6,14 @@
         "en": "Self-hosted remote torrent client",
         "fr": "Client torrent distant auto-hébergé"
     },
-    "version": "1.2.12~ynh1",
+    "version": "1.2.12~ynh2",
     "url": "https://github.com/boypt/simple-torrent",
     "license": "AGPL-3.0-only",
     "maintainer": {
-        "name": ""
+        "name": "eric_G"
     },
     "requirements": {
-        "yunohost": ">= 3.8.1"
+        "yunohost": ">= 4.0.0"
     },
     "multi_instance": true,
     "services": [

--- a/scripts/install
+++ b/scripts/install
@@ -143,7 +143,7 @@ chmod -R 755 /home/yunohost.$app/{torrents,downloads}
 #=================================================
 ynh_script_progression --message="Integrating service in YunoHost..." --weight=1
 
-yunohost service add $app --description "Self-hosted remote torrent client" --log "/var/log/$app/$app.log"
+yunohost service add $app --description "Self-hosted remote torrent client" --needs_exposed_ports $peer_port --log "/var/log/$app/$app.log"
 
 #=================================================
 # START SYSTEMD SERVICE

--- a/scripts/install
+++ b/scripts/install
@@ -143,7 +143,7 @@ chmod -R 755 /home/yunohost.$app/{torrents,downloads}
 #=================================================
 ynh_script_progression --message="Integrating service in YunoHost..." --weight=1
 
-yunohost service add $app --description "Self-hosted remote torrent client" --needs_exposed_ports $peer_port --log "/var/log/$app/$app.log"
+yunohost service add $app --description="Self-hosted remote torrent client" --needs_exposed_ports="$peer_port" --log="/var/log/$app/$app.log"
 
 #=================================================
 # START SYSTEMD SERVICE

--- a/scripts/restore
+++ b/scripts/restore
@@ -94,14 +94,14 @@ chmod -R 755 /home/yunohost.$app/{torrents,downloads}
 ynh_script_progression --message="Restoring the systemd configuration..." --weight=5
 
 ynh_restore_file --origin_path="/etc/systemd/system/$app.service"
-systemctl enable $app.service
+systemctl enable $app.service --quiet
 
 #=================================================
 # INTEGRATE SERVICE IN YUNOHOST
 #=================================================
 ynh_script_progression --message="Integrating service in YunoHost..."
 
-yunohost service add $app --description "Self-hosted remote torrent client" --needs_exposed_ports $peer_port --log "/var/log/$app/$app.log"
+yunohost service add $app --description="Self-hosted remote torrent client" --needs_exposed_ports="$peer_port" --log="/var/log/$app/$app.log"
 
 #=================================================
 # START SYSTEMD SERVICE

--- a/scripts/restore
+++ b/scripts/restore
@@ -101,7 +101,7 @@ systemctl enable $app.service
 #=================================================
 ynh_script_progression --message="Integrating service in YunoHost..."
 
-yunohost service add $app --description "Self-hosted remote torrent client" --log "/var/log/$app/$app.log"
+yunohost service add $app --description "Self-hosted remote torrent client" --needs_exposed_ports $peer_port --log "/var/log/$app/$app.log"
 
 #=================================================
 # START SYSTEMD SERVICE

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -132,7 +132,7 @@ chmod -R 755 /home/yunohost.$app/{torrents,downloads}
 #=================================================
 ynh_script_progression --message="Integrating service in YunoHost..."
 
-yunohost service add $app --description "Self-hosted remote torrent client" --log "/var/log/$app/$app.log"
+yunohost service add $app --description "Self-hosted remote torrent client" --needs_exposed_ports $peer_port --log "/var/log/$app/$app.log"
 
 #=================================================
 # START SYSTEMD SERVICE

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -132,7 +132,7 @@ chmod -R 755 /home/yunohost.$app/{torrents,downloads}
 #=================================================
 ynh_script_progression --message="Integrating service in YunoHost..."
 
-yunohost service add $app --description "Self-hosted remote torrent client" --needs_exposed_ports $peer_port --log "/var/log/$app/$app.log"
+yunohost service add $app --description="Self-hosted remote torrent client" --needs_exposed_ports="$peer_port" --log="/var/log/$app/$app.log"
 
 #=================================================
 # START SYSTEMD SERVICE


### PR DESCRIPTION
## Solution
- *Add --needs_exposed_ports $peer_port*

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Package_check results
---
*If you have access to [App Continuous Integration for packagers](https://yunohost.org/#/packaging_apps_ci) you can provide a link to the package_check results like below, replacing '-NUM-' in this link by the PR number and USERNAME by your username on the ci-apps-dev. Or you provide a screenshot or a pastebin of the results*

[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/simple-torrent_ynh%20PR11%20(ericgaspar)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/simple-torrent_ynh%20PR11%20(ericgaspar)/)  
